### PR TITLE
Deconstruct inputs

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -5,7 +5,7 @@ import "./tasks";
 // Since the blockchainID is not known in advance, there's no good default to use and we use the C-Chain here.
 var local_rpc_uri =
   process.env.RPC_URI ||
-  "http://127.0.0.1:9650/ext/bc/68JCdKgCacpJjBsP552dQu32noSYCPoowc5cUJ6o3v4DysZ1P/rpc";
+  "http://127.0.0.1:9650/ext/bc/Nr87kKgULn67r6NpeRpy1YXuHLApJMycC5H632YXHpUnGkYrT/rpc";
 // var local_rpc_uri = process.env.RPC_URI || "http://127.0.0.1:9650/ext/bc/C/rpc";
 var local_chain_id = parseInt(process.env.CHAIN_ID, 10) || 99999;
 // var local_chain_id = parseInt(process.env.CHAIN_ID, 10) || 43112;

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -5,7 +5,7 @@ import "./tasks";
 // Since the blockchainID is not known in advance, there's no good default to use and we use the C-Chain here.
 var local_rpc_uri =
   process.env.RPC_URI ||
-  "http://127.0.0.1:9650/ext/bc/jSVCaBfeTNcTYubxLU9EjHQGHxBMdMhg3F5joZ4abwzgyFiZ6/rpc";
+  "http://127.0.0.1:9650/ext/bc/68JCdKgCacpJjBsP552dQu32noSYCPoowc5cUJ6o3v4DysZ1P/rpc";
 // var local_rpc_uri = process.env.RPC_URI || "http://127.0.0.1:9650/ext/bc/C/rpc";
 var local_chain_id = parseInt(process.env.CHAIN_ID, 10) || 99999;
 // var local_chain_id = parseInt(process.env.CHAIN_ID, 10) || 43112;

--- a/contracts/test/llm.ts
+++ b/contracts/test/llm.ts
@@ -73,7 +73,9 @@ describe("ILLM", function () {
     const inputPrompt = `Hello World`;
     let promptIdRead: string;
 
-    let tx = await testContract.evaluatePrompt(inputPrompt);
+    let tx = await testContract.evaluatePrompt(JSON.stringify({
+      prompt: inputPrompt
+    }));
     await tx.wait();
     let methodData: string;
     let calleeContractAddress: string;
@@ -172,7 +174,9 @@ describe("ILLM", function () {
     // Read the JSON file containing the plans
     const fileContent = fs.readFileSync(planPath, "utf8");
     const plans = JSON.parse(fileContent);
-    const withLookupPlan = JSON.stringify(plans["basic"]);
+    const withLookupPlan = JSON.stringify({
+      plan: plans["basic"]
+    });
 
     const countAStart = await counterAContract.getCounter();
     const countBStart = await counterBContract.getCounter();
@@ -252,7 +256,7 @@ describe("ILLM", function () {
     // Read the JSON file containing the plans
     const fileContent = fs.readFileSync(planPath, "utf8");
     const plans = JSON.parse(fileContent);
-    const withLookupPlan = JSON.stringify(plans["withLookup"]);
+    const withLookupPlan = JSON.stringify({ plan: plans["withLookup"] });
 
     const countAStart = await counterAContract.getCounter();
     const countBStart = await counterBContract.getCounter();

--- a/contracts/test/llm.ts
+++ b/contracts/test/llm.ts
@@ -73,8 +73,18 @@ describe("ILLM", function () {
     const inputPrompt = `Hello World`;
     let promptIdRead: string;
 
+    // should fail when prompt key is not passed
+    let isFailed = false;
+    await testContract.evaluatePrompt(JSON.stringify({ plan: inputPrompt })).catch(err => {
+      isFailed = true;
+    });
+    expect(isFailed).to.be.true;
+
     let tx = await testContract.evaluatePrompt(JSON.stringify({
-      prompt: inputPrompt
+      prompt: inputPrompt,
+      lookupTable: JSON.stringify({
+        recipient: '0x000000000000000000000000000000000000dead'
+      })
     }));
     await tx.wait();
     let methodData: string;
@@ -171,11 +181,21 @@ describe("ILLM", function () {
   it("should test evaluatePlan and continueEvaluation basic", async function () {
     const planPath = path.resolve(__dirname, "llm_test_input_plans.json");
 
+    // should fail when plan is not passed
+    let isFailed = false;
+    await testContract.evaluatePlan(JSON.stringify({ prompt: '' })).catch(err => {
+      isFailed = true;
+    });
+    expect(isFailed).to.be.true;
+
     // Read the JSON file containing the plans
     const fileContent = fs.readFileSync(planPath, "utf8");
     const plans = JSON.parse(fileContent);
     const withLookupPlan = JSON.stringify({
-      plan: plans["basic"]
+      plan: JSON.stringify(plans["basic"]),
+      lookupTable: JSON.stringify({
+        recipient: '0x000000000000000000000000000000000000dead'
+      })
     });
 
     const countAStart = await counterAContract.getCounter();
@@ -256,7 +276,7 @@ describe("ILLM", function () {
     // Read the JSON file containing the plans
     const fileContent = fs.readFileSync(planPath, "utf8");
     const plans = JSON.parse(fileContent);
-    const withLookupPlan = JSON.stringify({ plan: plans["withLookup"] });
+    const withLookupPlan = JSON.stringify({ plan: JSON.stringify(plans["withLookup"]) });
 
     const countAStart = await counterAContract.getCounter();
     const countBStart = await counterBContract.getCounter();

--- a/precompile/contracts/llmprecompile/contract.go
+++ b/precompile/contracts/llmprecompile/contract.go
@@ -513,7 +513,7 @@ func continueEvaluation(accessibleState contract.AccessibleState, caller common.
 }
 
 // Helper function to parse JSON and extract "prompt"/"plan" and "lookupTable"
-func parseEvalInputJSON(input string) (string, string, error) {
+func parseEvalInputJSON(input string, expectedKey string) (string, string, error) {
 	// Parse the string into a JSON map
 	var parsed map[string]string
 	err := json.Unmarshal([]byte(input), &parsed)
@@ -521,17 +521,15 @@ func parseEvalInputJSON(input string) (string, string, error) {
 		return "", "", errors.New("failed to parse JSON: " + err.Error())
 	}
 
-	// Extract the required keys
-	evalData, ok1 := parsed["prompt"]
-	if !ok1 {
-		evalData, ok1 = parsed["plan"] // Fallback to "plan"
-	}
-	if !ok1 {
-		return "", "", errors.New("missing required key: 'prompt' or 'plan'")
+	// Extract the required key dynamically
+	evalData, ok := parsed[expectedKey]
+	if !ok {
+		return "", "", fmt.Errorf("missing required key: '%s'", expectedKey)
 	}
 
-	lookupTable, ok2 := parsed["lookupTable"]
-	if !ok2 {
+	// Extract lookupTable (optional)
+	lookupTable, ok := parsed["lookupTable"]
+	if !ok {
 		lookupTable = "" // Default to empty string if not present
 	}
 
@@ -548,7 +546,7 @@ func UnpackEvaluatePlanInput(input []byte) (string, string, error) {
 	}
 
 	unpacked := *abi.ConvertType(res[0], new(string)).(*string)
-    return parseEvalInputJSON(unpacked)
+    return parseEvalInputJSON(unpacked, "plan")
 }
 
 // PackEvaluatePlan packs [plan] of type string into the appropriate arguments for evaluatePlan.
@@ -690,8 +688,9 @@ func evaluatePlan(accessibleState contract.AccessibleState, caller common.Addres
         log.Printf("Error: Failed to unpack input. Error: %v", err)
         return nil, suppliedGas, err
     }
-    fmt.Println("Plan:", plan)
-    fmt.Println("LookupTable:", lookupTable)
+
+    log.Printf("Plan: %s", plan)
+    log.Printf("LookupTable: %s", lookupTable)
     
     // Parse input into steps
     var inputSteps []Step
@@ -721,7 +720,7 @@ func evaluatePrompt(accessibleState contract.AccessibleState, caller common.Addr
         return nil, suppliedGas, err
     }
     log.Printf("Input string: %s", prompt)
-    fmt.Println("LookupTable:", lookupTable)
+    log.Printf("LookupTable: %s", lookupTable)
 
     // Use pre-defined steps for evaluatePrompt
     if len(steps) == 0 {
@@ -740,7 +739,7 @@ func UnpackEvaluatePromptInput(input []byte) (string, string, error) {
 		return "", "", err
 	}
 	unpacked := *abi.ConvertType(res[0], new(string)).(*string)
-	return parseEvalInputJSON(unpacked)
+	return parseEvalInputJSON(unpacked, "prompt")
 }
 
 // PackEvaluatePrompt packs [prompt] of type string into the appropriate arguments for evaluatePrompt.

--- a/precompile/contracts/llmprecompile/contract.go
+++ b/precompile/contracts/llmprecompile/contract.go
@@ -519,15 +519,43 @@ func continueEvaluation(accessibleState contract.AccessibleState, caller common.
     return packedOutput, remainingGas, nil
 }
 
+// Helper function to parse JSON and extract "prompt"/"plan" and "lookupTable"
+func parseEvalInputJSON(input string) (string, string, error) {
+	// Parse the string into a JSON map
+	var parsed map[string]string
+	err := json.Unmarshal([]byte(input), &parsed)
+	if err != nil {
+		return "", "", errors.New("failed to parse JSON: " + err.Error())
+	}
+
+	// Extract the required keys
+	evalData, ok1 := parsed["prompt"]
+	if !ok1 {
+		evalData, ok1 = parsed["plan"] // Fallback to "plan"
+	}
+	if !ok1 {
+		return "", "", errors.New("missing required key: 'prompt' or 'plan'")
+	}
+
+	lookupTable, ok2 := parsed["lookupTable"]
+	if !ok2 {
+		lookupTable = "" // Default to empty string if not present
+	}
+
+	return evalData, lookupTable, nil
+}
+
 // UnpackEvaluatePlanInput attempts to unpack [input] into the string type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
-func UnpackEvaluatePlanInput(input []byte) (string, error) {
+func UnpackEvaluatePlanInput(input []byte) (string, string, error) {
+	// Unpack the input string
 	res, err := LLMPrecompileABI.UnpackInput("evaluatePlan", input, false)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
+
 	unpacked := *abi.ConvertType(res[0], new(string)).(*string)
-	return unpacked, nil
+    return parseEvalInputJSON(unpacked)
 }
 
 // PackEvaluatePlan packs [plan] of type string into the appropriate arguments for evaluatePlan.
@@ -664,16 +692,17 @@ func evaluatePlan(accessibleState contract.AccessibleState, caller common.Addres
     }
 
     // Unpack the input to retrieve the string argument
-    inputString, err := UnpackEvaluatePlanInput(input)
+    plan, lookupTable, err := UnpackEvaluatePlanInput(input)
     if err != nil {
         log.Printf("Error: Failed to unpack input. Error: %v", err)
         return nil, suppliedGas, err
     }
-    log.Printf("Input string: %s", inputString)
-
+    fmt.Println("Plan:", plan)
+    fmt.Println("LookupTable:", lookupTable)
+    
     // Parse input into steps
     var inputSteps []Step
-    if err := json.Unmarshal([]byte(inputString), &inputSteps); err != nil {
+    if err := json.Unmarshal([]byte(plan), &inputSteps); err != nil {
         log.Printf("Error: Failed to parse input string as steps. Error: %v", err)
         return nil, suppliedGas, fmt.Errorf("invalid input format: %w", err)
     }
@@ -693,12 +722,13 @@ func evaluatePrompt(accessibleState contract.AccessibleState, caller common.Addr
     }
 
     // Unpack the input to retrieve the string argument
-    inputString, err := UnpackEvaluatePromptInput(input)
+    prompt, lookupTable, err := UnpackEvaluatePromptInput(input)
     if err != nil {
         log.Printf("Error: Failed to unpack input. Error: %v", err)
         return nil, suppliedGas, err
     }
-    log.Printf("Input string: %s", inputString)
+    log.Printf("Input string: %s", prompt)
+    fmt.Println("LookupTable:", lookupTable)
 
     // Use pre-defined steps for evaluatePrompt
     if len(steps) == 0 {
@@ -711,13 +741,13 @@ func evaluatePrompt(accessibleState contract.AccessibleState, caller common.Addr
 
 // UnpackEvaluatePromptInput attempts to unpack [input] into the string type argument
 // assumes that [input] does not include selector (omits first 4 func signature bytes)
-func UnpackEvaluatePromptInput(input []byte) (string, error) {
+func UnpackEvaluatePromptInput(input []byte) (string, string, error) {
 	res, err := LLMPrecompileABI.UnpackInput("evaluatePrompt", input, false)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	unpacked := *abi.ConvertType(res[0], new(string)).(*string)
-	return unpacked, nil
+	return parseEvalInputJSON(unpacked)
 }
 
 // PackEvaluatePrompt packs [prompt] of type string into the appropriate arguments for evaluatePrompt.


### PR DESCRIPTION
The evaluatePrompt and evaluatePlan receives a json string now in the following format

evaluatePlan:
`{ plan: '{}', lookupTable: '{}' }`

evaluatePrompt:
`{ prompt: 'prompt', lookupTable: '{}' }`